### PR TITLE
Primitive Ch3 build support

### DIFF
--- a/CUE4Parse/UE4/Versions/EGame.cs
+++ b/CUE4Parse/UE4/Versions/EGame.cs
@@ -134,6 +134,7 @@ public enum EGame : uint
     GAME_UE5_0 = GameUtils.GameUe5Base + (0 << 16),
         GAME_MeetYourMaker = GAME_UE5_0 + 1,
         GAME_BlackMythWukong = GAME_UE5_0 + 2,
+        GAME_Fortnite_Ch3 = GAME_UE5_0 + 3,
     GAME_UE5_1 = GameUtils.GameUe5Base + (1 << 16),
         GAME_3on3FreeStyleRebound = GAME_UE5_1 + 1,
         GAME_Stalker2 = GAME_UE5_1 + 2,
@@ -220,6 +221,7 @@ public static class GameUtils
         {
             return game switch
             {
+                    EGame.GAME_Fortnite_Ch3 => new FPackageFileVersion(522, 1002),
                 < EGame.GAME_UE5_1 => new FPackageFileVersion(522, 1004),
                 < EGame.GAME_UE5_2 => new FPackageFileVersion(522, 1008),
                     EGame.GAME_TheFirstDescendant => new FPackageFileVersion(522, 1002),


### PR DESCRIPTION
Custom "Game" profile that addresses serialization issues with Ch3 builds. This alone is enough to get animation exporting working for the first 3 Seasons of Chapter 3, and allows for basic asset reading to not consistently abruptly end, not return bogus numbers, or in worse cases prevents it from straight up crashing the program entirely and memory leaking.

Skeletal and static meshes still do not work, but it's still useful for animations and such.

Profiles called "GAME_Fortnite_Ch3" as 3/4 of the seasons need this, if you have another name in mind I can obviously change it. 

<img width="2557" height="1397" alt="image" src="https://github.com/user-attachments/assets/95ec4198-2d65-452a-b4a8-c808d1253041" />
<img width="2557" height="1396" alt="image" src="https://github.com/user-attachments/assets/07b130d0-ec0e-42b7-b5c6-3c2cfdebb50e" />
